### PR TITLE
Add nodes_path in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,6 +40,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     webapp.vm.provision "chef_zero" do |chef|
       #chef.cookbooks_path = "../cookbooks"
       chef.roles_path = "roles"
+      chef.nodes_path = "nodes"
       chef.environments_path = "environments"
       chef.environment = "development"
       chef.data_bags_path = "data_bags"


### PR DESCRIPTION
This is to avoid following error when vagrant up 

```
There are errors in the configuration of this machine. Please fix
the following errors and try again:

chef zero provisioner:
* Missing required value for `chef.nodes_path'.
```